### PR TITLE
Fix for ncs 2 4 0

### DIFF
--- a/remote_controller/src/main.c
+++ b/remote_controller/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <dk_buttons_and_leds.h>
 #include "remote.h"
 
@@ -73,7 +73,7 @@ void on_data_received(struct bt_conn *conn, const uint8_t *const data, uint16_t 
     temp_str[len] = 0x00;
 
     LOG_INF("Received data on conn %p. Len: %d", (void *)conn, len);
-    LOG_INF("Data: %s", log_strdup(temp_str));
+    LOG_INF("Data: %s", temp_str);
 }
 
 void button_handler(uint32_t button_state, uint32_t has_changed)

--- a/remote_controller/src/remote_service/remote.h
+++ b/remote_controller/src/remote_service/remote.h
@@ -2,10 +2,10 @@
 #include <zephyr.h>
 #include <logging/log.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/hci.h>
 
 /** @brief UUID of the Remote Service. **/
 #define BT_UUID_REMOTE_SERV_VAL \


### PR DESCRIPTION
These are the changes needed for it to build on 2.4.0
```cmd
Building remote_controller
C:\WINDOWS\system32\cmd.exe /d /s /c "west build --build-dir c:/nrf/custom_ncs_ble_service_sample/remote_controller/build c:/nrf/custom_ncs_ble_service_sample/remote_controller"

[1/13] Building C object CMakeFiles/app.dir/src/main.c.obj
[2/13] Linking C static library app\libapp.a
[3/13] Linking C executable zephyr\zephyr_pre0.elf

[4/13] Generating dev_handles.c
[5/13] Building C object zephyr/CMakeFiles/zephyr_pre1.dir/misc/empty_file.c.obj
[6/13] Building C object zephyr/CMakeFiles/zephyr_pre1.dir/dev_handles.c.obj
[7/13] Linking C executable zephyr\zephyr_pre1.elf

[8/13] Generating linker.cmd
[9/13] Generating isr_tables.c, isrList.bin
[10/13] Building C object zephyr/CMakeFiles/zephyr_final.dir/misc/empty_file.c.obj
[11/13] Building C object zephyr/CMakeFiles/zephyr_final.dir/dev_handles.c.obj
[12/13] Building C object zephyr/CMakeFiles/zephyr_final.dir/isr_tables.c.obj
[13/13] Linking C executable zephyr\zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      188292 B         1 MB     17.96%
             RAM:       33352 B       256 KB     12.72%
        IDT_LIST:          0 GB         2 KB      0.00%
 *  Terminal will be reused by tasks, press any key to close it. 
 ```